### PR TITLE
Align tuv shipping wrapper to the right side of the footer for the DE market

### DIFF
--- a/src/static_files/styles/partials/shared.styl
+++ b/src/static_files/styles/partials/shared.styl
@@ -369,9 +369,8 @@
 				vertical-align middle
 
 	.tuv_price_shipping_wrapper
-		width 33%
-		margin 0 auto
-		top -30px
+		text-align right
+		position relative
 
 	@media (max-width: 1025)
 		.lower.container_24


### PR DESCRIPTION
Align tuv_shipping_wrapper to the right side of the footer_global and place it under the logos in the footer.

The tuv logo will be removed from the footer in the DE market. The div containing the datenschutz, agb, impressum will get a grid_11 class. 

![jj-de](https://cloud.githubusercontent.com/assets/1457152/7368727/5fa1d072-edab-11e4-8c8d-9d863a69d0aa.png)
